### PR TITLE
Fix/camera encoding

### DIFF
--- a/cameras.py
+++ b/cameras.py
@@ -3,7 +3,7 @@ This script defines the camera specs
 """
 
 RESOLUTIONS = {
-    "4K": (4096, 2160),
+    "4K": (3840, 2160),
     "2K": (2560, 1440),
     "1080p": (1920, 1080),
     "720p": (1280, 720),

--- a/siyi_sdk.py
+++ b/siyi_sdk.py
@@ -960,6 +960,7 @@ class SIYISDK:
                 set_param_msg = self._set_sub_stream_encoding_msg
             else:
                 raise RuntimeError("Unknown stream_type")
+            set_param_msg.seq = seq
             set_param_msg.stream_type = stream_type
             set_param_msg.success = bool(status)
             return True


### PR DESCRIPTION
This pull request fixes two small issues:
1. Using the correct resolution width for 4K
2. Using the sequence variable inside ``parseSetCameraEncodingParametersMsg``